### PR TITLE
Fix typo in cl function: lh → ll

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -15,7 +15,7 @@ function cl() {
  if [ $# = 0 ]; then
   cd && ls
  else
-  cd "$*" && lh
+  cd "$*" && ll
  fi
 }
 


### PR DESCRIPTION
Fix cl() function: replace undefined `lh` with `ll` (aliased to `ls -lh`) so directory listing works after cd.